### PR TITLE
Fixed bug about labels

### DIFF
--- a/R/compare.fits.R
+++ b/R/compare.fits.R
@@ -17,7 +17,7 @@
 ##' @export
 ##' @examples
 ##' #not yet
-compare.fits = function(formula, data, model1, model2=NULL, return.preds=F, silent=F, report.se=F, re=F,...){
+compare.fits = function(formula, data, model1, model2=NULL, return.preds=F, silent=F, report.se=F, re=F, pred.type="response", ...){
 
 	#### if mod2 is null..
 	if (is.null(model2)){
@@ -140,10 +140,9 @@ compare.fits = function(formula, data, model1, model2=NULL, return.preds=F, sile
 		pred.mod1 = data.frame(prediction = predict(model1, pred.values, interval=int), model=model1.type)
 	} else {	
 		int = ifelse(report.se, "confidence", "none")
-		pred.mod1 = data.frame(prediction = predict(model1, pred.values, type="response", interval=int), model= model1.type)		
-
+		pred.mod1 = data.frame(prediction = predict(model1, pred.values, type=pred.type, interval=int), model= model1.type)		
 	}
-	
+
 	#### generate separate predictions for random effects
 	if ((model2.type == "lmerMod" | model2.type == "glmerMod") & re){
 		pred.mod2 = data.frame(prediction = predict(model2, pred.values, type="response"), model= "random effects")	
@@ -156,7 +155,7 @@ compare.fits = function(formula, data, model1, model2=NULL, return.preds=F, sile
 		int = ifelse(report.se, "confidence", "none")
 		pred.mod2 = data.frame(prediction = predict(model2, pred.values, interval="confidence")[,1], model=model2.type)
 	} else {
-		pred.mod2 = data.frame(prediction = predict(model2, pred.values, type="response"), model= model2.type)		
+		pred.mod2 = data.frame(prediction = predict(model2, pred.values, type= pred.type), model= model2.type)		
 	}
 	
 	#### convert polyr back to numeric (if applicable)

--- a/R/flexplot.R
+++ b/R/flexplot.R
@@ -228,7 +228,10 @@ flexplot = function(formula, data=NULL, related=F,
 					stop("It looks like you forgot to name your breaks. Be sure to do that. (e.g., breaks = list(variable1=c(5, 10, 15)), variable2=c(0,1,2))")
 				}
 			}
-						
+			
+			if (!is.null(labels)){
+				bins = length(labels[[i]])
+			}			
 			breaks[[break.me[i]]] = prep.breaks(variable=break.me[i], data, breaks=breaks[[break.me[i]]], bins)
 		}
 	} 
@@ -389,7 +392,7 @@ flexplot = function(formula, data=NULL, related=F,
 			binned.name = paste0(given[i], "_binned")
 
 			if (is.numeric(data[,given[i]])){
-				data[,binned.name] = bin.me(given[i], data, bins, labels[i], breaks[[given[i]]])
+				data[,binned.name] = bin.me(variable=given[i], data, bins, labels=labels[i], breaks=breaks[[given[i]]])
 				
 				### if they specified prediction, bin those too
 				if (!is.null(prediction)){


### PR DESCRIPTION
When a uses specified labels, the breaks would default to selecting 3 bins, regardless of the number of labels. This fixes things such that the number of bins is chosen based on the number of labels. 