### PR TITLE
Fix errors in (JASP) R/QML and add empty placeholders

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,16 +1,15 @@
 Package: flexplot
 Type: Package
 Title: Graphically Based Data Analysis Using Flexplot
-Version: 0.7.2
+Version: 0.7.3
 Author: Dustin Fife
 Maintainer: Dustin Fife <fife.dustin@gmail.com>
 Description: The ‘flexplot’ suite is a graphically-based set of tools for doing data analysis. flexplot() allows users to specify a formula and the software automatically chooses what sort of graphic to present. Analysis can be paired with visuals using the visualize() function, such that the software will choose an appropriate graphic to match an R model object.
 License: GPL-2
 Encoding: UTF-8
 LazyData: true
-Depends: stats
+Depends: stats, ggplot2
 Imports: cowplot, 
-	ggplot2, 
 	MASS, 
 	tibble, 
 	withr, 

--- a/R/flexplot_jasp2.R
+++ b/R/flexplot_jasp2.R
@@ -10,154 +10,133 @@
 #' @return a flexplot graphic. 
 #' @export
 flexplot_jasp2 = function(jaspResults, dataset, options) {
-
-	### check if they've entered anything	  
+  
+  ### check if they've entered anything	  
   #save(dataset, options, file="~/Documents/JaspResults.Rdat")
-	ready <- (options$dependent != "") 
-	  
-	### read in the dataset 
-	if (ready) {
-		### read in the dataset
-		if (is.null(dataset)){ 
-    		dataset = (.readDataSetToEnd(columns=c(options$dependent, options$variables, options$paneledVars)))
-    		#save(dataset, ready, options, file="~/Users/Documents/jaspdata.rdat")
-		} else {
-			return(dataset) 
-		}
-	  
-		### create plots
-		.flexPlotRes(jaspResults, formula, dataset, options, ready)
-		
-		return()	  
-		#}  
-	} else {
-		return()
-	} 
+  ready <- (options$dependent != "") 
+  
+  ### read in the dataset 
+  if (ready) {
+    ### read in the dataset
+    if (is.null(dataset)){ 
+      dataset = (.readDataSetToEnd(columns=c(options$dependent, options$variables, options$paneledVars)))
+      #save(dataset, ready, options, file="~/Users/Documents/jaspdata.rdat")
+    } else {
+      return(dataset) 
+    }
+  }
+  
+  ### create plots
+  .flexPlotRes(jaspResults, formula, dataset, options, ready)
 }
 
 
 .flexPlotRes <- function(jaspResults, formula, dataset, options, ready) {
-	
-	#### set up parameters
-	flex_Plot <- createJaspPlot(title = "Flexplot",  width = 600, height = 450)
-	flex_Plot$dependOn(c("confidence", "dependent", "variables", "paneledVars", "ghostLines"))
-	flex_Plot$addCitation("Fife, Dustin A. (2019). Flexplot (Version 0.9.2) [Computer software].")
-	
-	#### pre-populate the jasp object
-	jaspResults[["flex_Plot"]] <- flex_Plot
-
-	if (!ready){
-		return()
-	}
-   
-		#### prepare the data for flexplot
-		k = data.frame(matrix(nrow=nrow(dataset), ncol=length(options$variables) + length(options$dependent) + length(options$paneledVars)))
-		names(k) = c(options$dependent, options$variables, options$paneledVars)
-		variables <- unlist(options$variables)
-		panels <- unlist(options$paneledVars)
-		if (length(panels)>0){
-			vars = c(variables, panels)
-		} else {
-			vars = variables
-		}
-		k[,1] = dataset[[.v(options$dependent)]]
-		if (length(vars)>0){		#### this statement is necessary to allow histograms
-			for (i in 2:(length(vars)+1)){
-				k[,i] = dataset[[.v(vars[i-1])]]
-			}
-		}
-
-		if (length(options$variables)==0){
-			formula = as.formula(paste0(options$dependent, "~1"))		
-		} else if (length(options$paneledVars)>0){
-			formula = as.formula(paste0(options$dependent, "~", paste0(variables, collapse="+"), " | ", paste0(panels, collapse="+")))
-		} else {
-			formula = as.formula(paste0(options$dependent, "~", paste0(variables, collapse="+")))
-		}
-		tst = data.frame(x=1:10, y=1:10)
-		require(ggplot2)
-		
-		#### do a ghost line
-		if	(options$ghost){
-		  ghost=rgb(195/255,0,0,.3) 
-		} else {
-		  ghost = NULL
-		}
-		
-		whiskers = list("Quartiles" = "quartiles",
-		                "Standard errors" = "sterr",
-		                "Standard deviations" = "stdev")
-
-		linetype = tolower(options$type)
-		
-		#save(k, formula, file="/Users/fife/Documents/jaspbroke.rdata")
-		jitter = c(options$jitx,options$jity)
-		if (linetype == "regression") linetype = "lm"
-		plot = flexplot(formula, data=k, method=linetype, se=options$confidence, alpha=options$alpha, 
-		                ghost.line=ghost,
-		                spread=whiskers[[options$intervals]],
-		                jitter = jitter)
-		
-		if (options$theme == "JASP"){
-		  plot = themeJasp(plot)
-		} else {
-  		theme = list("black and white"="theme_bw()+ theme(text=element_text(size=18))",
-  		                  "minimal" = "theme_minimal()+ theme(text=element_text(size=18))",
-  		                 "classic" = "theme_classic()+ theme(text=element_text(size=18))",
-  		                 "dark" = "theme_dark() + theme(text=element_text(size=18))")
-  		plot = plot + eval(parse(text=theme[[tolower(options$theme)]]))
-		}
-		
-		# #### create flexplot object   
-		flex_Plot$plotObject <- plot
-		return()   
-}   
-
+  #### set up parameters
+  flex_Plot <- createJaspPlot(title = "Flexplot",  width = 600, height = 450)
+  flex_Plot$dependOn(c("confidence", "dependent", "variables", "paneledVars", "ghostLines"))
+  flex_Plot$addCitation("Fife, Dustin A. (2019). Flexplot (Version 0.9.2) [Computer software].")
   
-.flexplotFill <- function(flex_Plot, formula, dataset, options){
- 
-  return()
+  #### pre-populate the jasp object
+  jaspResults[["flex_Plot"]] <- flex_Plot
+  
+  if (!ready){
+    return()
+  }
+  
+  #### prepare the data for flexplot
+  k = data.frame(matrix(nrow=nrow(dataset), ncol=length(options$variables) + length(options$dependent) + length(options$paneledVars)))
+  names(k) = c(options$dependent, options$variables, options$paneledVars)
+  variables <- unlist(options$variables)
+  panels <- unlist(options$paneledVars)
+  if (length(panels)>0){
+    vars = c(variables, panels)
+  } else {
+    vars = variables
+  }
+  k[,1] = dataset[[.v(options$dependent)]]
+  if (length(vars)>0){		#### this statement is necessary to allow histograms
+    for (i in 2:(length(vars)+1)){
+      k[,i] = dataset[[.v(vars[i-1])]]
+    }
+  }
+  
+  if (length(options$variables)==0){
+    formula = as.formula(paste0(options$dependent, "~1"))		
+  } else if (length(options$paneledVars)>0){
+    formula = as.formula(paste0(options$dependent, "~", paste0(variables, collapse="+"), " | ", paste0(panels, collapse="+")))
+  } else {
+    formula = as.formula(paste0(options$dependent, "~", paste0(variables, collapse="+")))
+  }
+  tst = data.frame(x=1:10, y=1:10)
+  
+  #### do a ghost line
+  if	(options$ghost){
+    ghost=rgb(195/255,0,0,.3) 
+  } else {
+    ghost = NULL
+  }
+  
+  whiskers = list("Quartiles" = "quartiles",
+                  "Standard errors" = "sterr",
+                  "Standard deviations" = "stdev")
+  
+  linetype = tolower(options$type)
+  
+  #save(k, formula, file="/Users/fife/Documents/jaspbroke.rdata")
+  jitter = c(options$jitx,options$jity)
+  if (linetype == "regression") linetype = "lm"
+  
+  plot = flexplot(formula, data=k, method=linetype, se=options$confidence, alpha=options$alpha,
+                            ghost.line=ghost,
+                            spread=whiskers[[options$intervals]],
+                            jitter = jitter)
+  
+  plot <- theme_it(plot, options$theme)
+  
+  # #### create flexplot object   
+  flex_Plot$plotObject <- plot
+  return()   
 }
 
-
-	#### create a table
+#### create a table
 .printedResults = function(jaspResults, dataset, options, ready){
-
-	if (!is.null(jaspResults[["resultsTable"]])) return()
-  	
-	# Create Table
-	resultsTable <- createJaspTable(title="Flexplot Table")
-    resultsTable$dependOn(c("variables", "dependent", "confidence", "type"))
-	resultsTable$addCitation("Fife, Dustin A. (2019). Flexplot (Version 0.9.2) [Computer software].")
-
-	resultsTable$showSpecifiedColumnsOnly <- TRUE
-  	
-	### add columns to table
-	resultsTable$addColumnInfo(name = "var",   title = "Variable",   type = "string", combine = TRUE)
-	resultsTable$addColumnInfo(name = "mean",   title = "Mean",   type = "string", combine = TRUE)	
-	resultsTable$addColumnInfo(name = "median",   title = "Median",   type = "string", combine = TRUE)	
-	resultsTable$addColumnInfo(name = "typ",   title = "Type",   type = "string", combine = TRUE)	
-	
-	#### tell jasp how many rows we expect
-	if (ready)
-	resultsTable$setExpectedSize(length(options$variables))
-	
-	for (variable in options$variables){
-		#row <- c(variable, options$dependent, options$confidence, options$type)
-		resultsTable$addRows(list(
-						"var" = variable,
-						"mean" = mean(dataset[[.v(variable)]]),
-						"median" = median(dataset[[.v(variable)]]), 
-						"typ" = mode(dataset[[.v(variable)]])))
-	}
-	#f <- paste0(options$dependent, "~", paste0(options$variables, collapse="+"))
-	#message <- options$variables
-	resultsTable$addFootnote(message="hello", symbol="<em>Note.</em>")	
-	
-	jaspResults[["resultsTable"]] <- resultsTable
+  
+  if (!is.null(jaspResults[["resultsTable"]])) return()
+  
+  # Create Table
+  resultsTable <- createJaspTable(title="Flexplot Table")
+  resultsTable$dependOn(c("variables", "dependent", "confidence", "type"))
+  resultsTable$addCitation("Fife, Dustin A. (2019). Flexplot (Version 0.9.2) [Computer software].")
+  
+  resultsTable$showSpecifiedColumnsOnly <- TRUE
+  
+  ### add columns to table
+  resultsTable$addColumnInfo(name = "var",   title = "Variable",   type = "string", combine = TRUE)
+  resultsTable$addColumnInfo(name = "mean",   title = "Mean",   type = "string", combine = TRUE)	
+  resultsTable$addColumnInfo(name = "median",   title = "Median",   type = "string", combine = TRUE)	
+  resultsTable$addColumnInfo(name = "typ",   title = "Type",   type = "string", combine = TRUE)	
+  
+  #### tell jasp how many rows we expect
+  if (ready)
+    resultsTable$setExpectedSize(length(options$variables))
+  
+  for (variable in options$variables){
+    #row <- c(variable, options$dependent, options$confidence, options$type)
+    resultsTable$addRows(list(
+      "var" = variable,
+      "mean" = mean(dataset[[.v(variable)]]),
+      "median" = median(dataset[[.v(variable)]]), 
+      "typ" = mode(dataset[[.v(variable)]])))
+  }
+  #f <- paste0(options$dependent, "~", paste0(options$variables, collapse="+"))
+  #message <- options$variables
+  resultsTable$addFootnote(message="hello", symbol="<em>Note.</em>")	
+  
+  jaspResults[["resultsTable"]] <- resultsTable
 }
 
-	#### read in data
+#### read in data
 .flexReadData <- function(dataset, options) {
   if (!is.null(dataset))
     return(dataset)

--- a/R/glinmod_jasp.R
+++ b/R/glinmod_jasp.R
@@ -12,7 +12,7 @@
 glinmod_jasp<- function(jaspResults, dataset, options) {
 
   ### check if they have an IV and a DV
-  ready <- (options$dependent != "" & length(options$variables)>0)
+  ready <- (options$dependent != "" && length(options$variables)>0)
   
   ### read in the dataset if it's ready
   if (ready){
@@ -30,35 +30,34 @@ glinmod_jasp<- function(jaspResults, dataset, options) {
     }
     character = sapply(dataset[,options$variables, drop=F], check.non.number)
     numeric = !character
-    
-    #### compute results
-    if (is.null(jaspResults[["glinmod_results"]]))
-      .glinmod_compute(jaspResults, dataset, options, ready)
-    
-    
-    #### show plots (if user specifies them)
-    if (options$model) {
-      if (is.null(jaspResults[["glinmod_model_plot"]])){
-        .glinmod_model_plot(jaspResults, options, ready, dataset)
-      }
+  }
+  
+  #### compute results
+  if (is.null(jaspResults[["glinmod_results"]]))
+    .glinmod_compute(jaspResults, dataset, options, ready)
+  
+  
+  #### show plots (if user specifies them)
+  if (options$model) {
+    if (is.null(jaspResults[["glinmod_model_plot"]])){
+      .glinmod_model_plot(jaspResults, options, ready, dataset)
     }
-    
-    #### show plots (if user specifies them)
-    if (options$univariates) {
-      if (is.null(jaspResults[["glinmod_univariate_plot"]])){
-        .glinmod_univariate_plot(jaspResults, options, ready, dataset)
-      }
+  }
+  
+  #### show plots (if user specifies them)
+  if (options$univariates) {
+    if (is.null(jaspResults[["glinmod_univariate_plot"]])){
+      .glinmod_univariate_plot(jaspResults, options, ready, dataset)
     }
-    
-    ### report parameter estimates
-    if (options$ests){
-      if (is.null(jaspResults[["glinmod_table_fixed"]])){
-        .create_glinmod_coefs(jaspResults, options, ready)
-      }
+  }
+  
+  ### report parameter estimates
+  if (options$ests){
+    if (is.null(jaspResults[["glinmod_table_fixed"]])){
+      .create_glinmod_coefs(jaspResults, options, ready)
     }
-
-
-  }  
+  }
+  
 }
 
 
@@ -193,7 +192,7 @@ glinmod_jasp<- function(jaspResults, dataset, options) {
 .fill_glinmod_table_fixed = function(glinmod_table_fixed, glinmod_results){
   
   factors = summary(glinmod_results)$coefficients
-  term.labels = gsub(":", "x", row.names(factors))
+  term.labels = gsub(":", "\u2009\u273b\u2009", row.names(factors))
   
   ### output results
   tabdat = list(
@@ -265,7 +264,7 @@ glinmod_jasp<- function(jaspResults, dataset, options) {
     return(dataset)
   else
     dataset = .readDataSetToEnd(columns=(c(options$dependent, options$variables))) 
-    ## variable names in the dataset are encoded. de-encodify them
-    names(dataset) = JASP:::.unv(names(dataset))
-    return(dataset)
+  ## variable names in the dataset are encoded. de-encodify them
+  names(dataset) = JASP:::.unv(names(dataset))
+  return(dataset)
 }

--- a/R/jasp_common.R
+++ b/R/jasp_common.R
@@ -23,17 +23,29 @@ arrange_jasp_plots = function(plot_list, theme){
   return(plot)
 }
 
-theme_it = function(plot, theme){
-  if (theme == "JASP"){
+theme_it = function(plot, theme) {
+  originalTheme <- theme
+  theme <- tolower(theme)
+  if (!theme %in% c("jasp", "black and white", "minimal", "classic", "dark"))
+    stop("Invalid theme provided: ", originalTheme)
+  
+  if (theme == "jasp")
     plot = themeJasp(plot)
-  } else {
-    themes = list("Black and white"="theme_bw()+ theme(text=element_text(size=18))",
-                 "Minimal" = "theme_minimal()+ theme(text=element_text(size=18))",
-                 "Classic" = "theme_classic()+ theme(text=element_text(size=18))",
-                 "Dark" = "theme_dark() + theme(text=element_text(size=18))")
-    plot = plot + eval(parse(text=themes[[theme]]))
-  }
+  else
+    plot = addGgplotThemeLayer(plot, theme)
+  
   return(plot)
+}
+
+addGgplotThemeLayer <- function(plot, theme) {
+  plotTheme <- switch(theme,
+                      "black and white" = theme_bw(),
+                      "minimal"         = theme_minimal(),
+                      "classic"         = theme_classic(),
+                      "dark"            = theme_dark())
+  plotTheme <- plotTheme + theme(text=element_text(size=18))
+  
+  return(plot + plotTheme)
 }
 
 modify_dv = function(dataset, outcome, family){

--- a/R/make.formula.R
+++ b/R/make.formula.R
@@ -19,14 +19,16 @@
 ##' make.formula("A", LETTERS[2:5], random="(1|group)")
 make.formula = function(response, predictors, random=NULL){
 	if (is.null(random)){
-		formula(paste(response, "~", 
+		formula <- paste(response, "~", 
 					paste(predictors, collapse="+"),
-				sep=""))
+				sep="")
 	} else {
-		formula(paste(response, "~", 
+	  formula <- paste(response, "~", 
 					paste(predictors, collapse="+"),
 					"+",random,
-				sep=""))
+				sep="")
 	}
+  return(as.formula(formula, env = parent.frame(1)))
+  
 }
 

--- a/inst/qml/Flexplot.qml
+++ b/inst/qml/Flexplot.qml
@@ -1,112 +1,102 @@
-import QtQuick 2.8
-import JASP.Controls 1.0
-import JASP.Widgets 1.0
-import JASP.Theme 1.0
+import QtQuick			2.12
+import JASP.Controls	1.0
+import JASP.Widgets		1.0
+import JASP				1.0
+
 Form 
 {
-    usesJaspResults: true
+	usesJaspResults: true
 
-    VariablesForm
+	VariablesForm
 	{
-        AvailableVariablesList { name: "allVariables" }
+		AvailableVariablesList	{ name: "allVariables" }
+		AssignedVariablesList	{ name: "dependent"		; title: qsTr("Dependent Variable")	; singleVariable: true	}
+		AssignedVariablesList	{ name: "variables"		; title: qsTr("Independent Variable(s)") ; id: varlist		}
+		AssignedVariablesList	{ name: "paneledVars"	; title: qsTr("Panelled Variable(s)")	 ; id: paneledVars	}
+	}
 
-        AssignedVariablesList 
-		{ 
-			name: "dependent";	
-			title: qsTr("Dependent Variable");
-			singleVariable: true 
-		}
-        
-		AssignedVariablesList 
-		{ 
-		  id: varlist
-			name: "variables";	
-			title: qsTr("Independent Variable(s)");
-			singleVariable: false 
-		}
-        
-		AssignedVariablesList 
+	Section
+	{
+		title: qsTr("Options")
+
+		Group
 		{
-  		id: paneledVars
-			name: "paneledVars";	
-			title: qsTr("Panelled Variable(s)");
-			singleVariable: false 
+			title: qsTr("Point controls")
+			columns: 4
+			Slider
+			{
+				name: "alpha"
+				label: qsTr("Point transparency")
+				value: 0.4
+				vertical: true
+				enabled: varlist.count > 0
+			}
+			Slider
+			{
+				name: "jitx"
+				label: qsTr("Jitter in X")
+				value: .1
+				min: 0
+				max: .5
+				vertical: true
+				enabled: varlist.count > 0
+			}
+			Slider
+			{
+				name: "jity"
+				label: qsTr("Jitter in Y")
+				value: 0
+				min: 0
+				max: .5
+				vertical: true
+				enabled: varlist.count > 0
+			}
 		}
+		Group
+		{
+			Group
+			{
+				title: qsTr("Visual Statistics")
+				CheckBox
+				{
+					name:"confidence";
+					label: qsTr("Plot confidence bands")
+					enabled: varlist.count > 0
+				}
+				DropDown
+				{
+					name: "type"
+					values: ["Loess", "Regression", "Quadratic", "Cubic"]
+					label: qsTr("Fitted line (scatterplots)")
+					enabled: varlist.count > 0
+				}
+				DropDown
+				{
+					name: "intervals"
+					values: ["Quartiles", "Standard errors", "Standard deviations"]
+					label: qsTr("Intervals (categorical predictors)")
+					enabled: varlist.count > 0
+				}
+			}
 
-  }
-
-  ExpanderButton
-  {
-      title: qsTr("Options")
-      
-        Group{
-        title: qsTr("Point controls")
-        columns: 4
-		        Slider{
-              name: "alpha"
-              label: qsTr("Point transparency")
-              value: 0.4
-              vertical: true
-              enabled: varlist.count > 0
-            }
-		        Slider{
-              name: "jitx"
-              label: qsTr("Jitter in X")
-              value: .1
-              min: 0
-              max: .5
-              vertical: true
-              enabled: varlist.count > 0
-            }  
-		        Slider{
-              name: "jity"
-              label: qsTr("Jitter in Y")
-              value: 0
-              min: 0
-              max: .5
-              vertical: true
-              enabled: varlist.count > 0
-            }   
-        }
-        Group{
-        Group{
-        title: qsTr("Visual Statistics")
-            CheckBox{
-              name:"confidence"; 
-              label: qsTr("Plot confidence bands")
-               enabled: varlist.count > 0
-            }
-		        DropDown{
-			        name: "type"
-			        values: ["Loess", "Regression", "Quadratic", "Cubic"]
-			        label: qsTr("Fitted line (scatterplots)")
-			         enabled: varlist.count > 0
-		        }
-		        DropDown{
-			        name: "intervals"
-			        values: ["Quartiles", "Standard errors", "Standard deviations"]
-			        label: qsTr("Intervals (categorical predictors)")
-			         enabled: varlist.count > 0
-		        }		        
-        }        
-        
-        Group{
-        title: qsTr("Other Plot Controls")
-            DropDown{
-			        name: "theme"
-			        values: ["JASP", "Black and white", "Minimal", "Classic", "Dark"]
-			        label: qsTr("GGplot theme")
-		        }
-		        CheckBox{
-              name:"ghost"; 
-              label: qsTr("Ghost lines");
-              checked: true
-              enabled: paneledVars.count > 0 
-            }
-        }
-        }
-        
-
-  }
+			Group
+			{
+				title: qsTr("Other Plot Controls")
+				DropDown
+				{
+					name: "theme"
+					values: ["JASP", "Black and white", "Minimal", "Classic", "Dark"]
+					label: qsTr("GGplot theme")
+				}
+				CheckBox
+				{
+					name:"ghost";
+					label: qsTr("Ghost lines");
+					checked: true
+					enabled: paneledVars.count > 0
+				}
+			}
+		}
+	}
 
 }

--- a/inst/qml/glinmod.qml
+++ b/inst/qml/glinmod.qml
@@ -1,154 +1,130 @@
-import QtQuick 2.8
-import JASP.Controls 1.0
-import JASP.Widgets 1.0
-import JASP.Theme 1.0
+import QtQuick			2.12
+import JASP.Controls	1.0
+import JASP.Widgets		1.0
+import JASP				1.0
+
 Form 
 {
-  usesJaspResults: true
+	usesJaspResults: true
 
-  VariablesForm
+	VariablesForm
 	{
-    AvailableVariablesList { 
-      name: "allVariables" 
-    }
-    AssignedVariablesList { 
-			name: "dependent";	
-			title: qsTr("Dependent Variable");
-			singleVariable: true 
+		AvailableVariablesList	{ name: "allVariables" }
+		AssignedVariablesList	{ name: "dependent"	; title: qsTr("Dependent Variable")			; singleVariable: true	}
+		AssignedVariablesList	{ name: "variables"	; title: qsTr("Independent Variable(s)")	; id: vars				}
+		DropDown
+		{
+			id: family
+			name: "family"
+			values: ["Normal", "Logistic", "Poisson", "Negative binomial", "Gamma"]
+			label: qsTr("Distribution family")
 		}
-		AssignedVariablesList { 
-		  id: vars
-			name: "variables";	
-			title: qsTr("Independent Variable(s)");
-			singleVariable: false 
+	}
+
+
+	Section
+	{
+		title: qsTr("Interaction terms")
+		enabled: vars.count > 1
+		VariablesForm
+		{
+			height: 150
+			AvailableVariablesList	{ name: "components"	; title: qsTr("Components")		; source: ["variables"]				}
+			AssignedVariablesList	{ name: "interactions"	; title: qsTr("Model terms")	; listViewType: JASP.Interaction	}
 		}
-		DropDown{
-		    id: family
-			  name: "family"
-			  values: ["Normal", "Logistic", "Poisson", "Negative binomial", "Gamma"]
-			  label: qsTr("Distribution family")
-		  }
-  }
-  
+	}
+
+	/* ExpanderButton{
+	title: qsTr("Family and Link Function")
 
 
-  
-  ExpanderButton{
-    title: qsTr("Interaction terms")  
-    enabled: vars.count > 1    
-    VariablesForm
-    {
-      height: 150
-      AvailableVariablesList { 
-        name: "components"; 
-        title: qsTr("Components"); 
-        source: ["variables"] 
-      }
-  
-      AssignedVariablesList 
-      { 
-        name: "interactions"; 
-        title: qsTr("Model terms"); 
-        listViewType:"Interaction"
-      }
-    }
-  }  
 
- /* ExpanderButton{
-    title: qsTr("Family and Link Function")  
-
-		  
-  
 		  DropDown{
 			  name: "link"
 			  values: ["identity", "logit", "log", "inverse", "custom..."]
 			  {
-			    if (["Normal", "Logistic"].includes(family.currentText)) return ["identity", "logit", "log", "inverse", "custom..."]
-			    else if (["Poisson", "Gamma"].includes(family.currentText)) return ["inverse", "custom..."]
-			    else return ["identity", "test"]
-			   } 
+				if (["Normal", "Logistic"].includes(family.currentText)) return ["identity", "logit", "log", "inverse", "custom..."]
+				else if (["Poisson", "Gamma"].includes(family.currentText)) return ["inverse", "custom..."]
+				else return ["identity", "test"]
+			   }
 			  label: qsTr("Link function")
-		  }	
+		  }
   }  */
 
-		
-  ExpanderButton{
-    title: qsTr("Results Displays")
 
-    Group{
-    title: qsTr("Plots")
-		  CheckBox{
-			  name:"model"; 
-			  label: qsTr("Model plot");
-			  checked: true
-			  }
-      CheckBox{
-			  name:"univariates"; 
-			  label: qsTr("Univariates")
-			  }			  
-		  }
-		  
-		  
-		Group{
-    title: qsTr("Estimation")
-      CheckBox{
-			  name:"ests"; 
-			  label: qsTr("Show parameter Estimates")
-			  checked: true
-			}	
+	Section
+	{
+		title: qsTr("Results Displays")
+
+		Group
+		{
+			title: qsTr("Plots")
+			CheckBox { name:"model"			; label: qsTr("Model plot")	; checked: true	}
+			CheckBox { name:"univariates"	; label: qsTr("Univariates")				}
 		}
+
+
+		Group
+		{
+			title: qsTr("Estimation")
+			CheckBox { name:"ests"			; label: qsTr("Show parameter Estimates"); checked: true }
 		}
-		
-		  ExpanderButton
-  {
-      title: qsTr("Plot Controls")
-      
-        Group{
-        title: qsTr("Point controls")
-        columns: 4
-		        Slider{
-              name: "alpha"
-              label: qsTr("Point transparency")
-              value: 0.4
-              vertical: true
-              enabled: varlist.count > 0
-            }
-		        Slider{
-              name: "jitx"
-              label: qsTr("Jitter in X")
-              value: 0
-              min: 0
-              max: .5
-              vertical: true
-              enabled: varlist.count > 0
-            }  
-		        Slider{
-              name: "jity"
-              label: qsTr("Jitter in Y")
-              value: 0
-              min: 0
-              max: .5
-              vertical: true
-              enabled: varlist.count > 0
-            }   
-        }
-        Group{
-        title: qsTr("Aesthetics")
-            DropDown{
-			        name: "theme"
-			        values: ["JASP", "Black and white", "Minimal", "Classic", "Dark"]
-			        label: qsTr("GGplot theme")
-		        }
-		        CheckBox{
-              name:"ghost"; 
-              label: qsTr("Ghost lines");
-              checked: true
-              enabled: vars.count > 1 & vars.count< 4
-            }  
-        }
+	}
 
-  }
-  
+	Section
+	{
+		title: qsTr("Plot Controls")
 
-  
+		Group
+		{
+			title: qsTr("Point controls")
+			columns: 4
+			Slider
+			{
+				name: "alpha"
+				label: qsTr("Point transparency")
+				value: 0.4
+				vertical: true
+				enabled: varlist.count > 0
+			}
+			Slider
+			{
+				name: "jitx"
+				label: qsTr("Jitter in X")
+				value: 0
+				min: 0
+				max: .5
+				vertical: true
+				enabled: varlist.count > 0
+			}
+			Slider
+			{
+				name: "jity"
+				label: qsTr("Jitter in Y")
+				value: 0
+				min: 0
+				max: .5
+				vertical: true
+				enabled: varlist.count > 0
+			}
+		}
+		Group
+		{
+			title: qsTr("Aesthetics")
+			DropDown
+			{
+				name: "theme"
+				values: ["JASP", "Black and white", "Minimal", "Classic", "Dark"]
+				label: qsTr("GGplot theme")
+			}
+			CheckBox
+			{
+				name:"ghost";
+				label: qsTr("Ghost lines");
+				checked: true
+				enabled: vars.count > 1 & vars.count< 4
+			}
+		}
+
+	}
 }

--- a/inst/qml/linmod.qml
+++ b/inst/qml/linmod.qml
@@ -1,176 +1,124 @@
-import QtQuick 2.8
-import JASP.Controls 1.0
-import JASP.Widgets 1.0
-import JASP.Theme 1.0
+import QtQuick			2.12
+import JASP.Controls	1.0
+import JASP.Widgets		1.0
+import JASP				1.0
+
 Form 
 {
-  usesJaspResults: true
-
-  VariablesForm
+	VariablesForm
 	{
-    AvailableVariablesList { 
-      name: "allVariables" 
-    }
-    AssignedVariablesList { 
-			name: "dependent";	
-			title: qsTr("Dependent Variable");
-			singleVariable: true;
-			allowedColumns: ["scale"]
-		}
-		AssignedVariablesList { 
-		  id: vars
-			name: "variables";	
-			title: qsTr("Independent Variable(s)");
-			singleVariable: false 
-		}
-  }
+		AvailableVariablesList	{ name: "allVariables" }
+		AssignedVariablesList	{ name: "dependent"	; title: qsTr("Dependent Variable")		; singleVariable: true	; allowedColumns: ["scale"]	}
+		AssignedVariablesList	{ name: "variables"	; title: qsTr("Independent Variable(s)"); id: varlist											}
+	}
 
-  ExpanderButton{
-    title: qsTr("Model Terms");  
-    enabled: vars.count > 1 
-    VariablesForm
-    {
-      height: 150
-      AvailableVariablesList { 
-        name: "components"; 
-        title: qsTr("Components"); 
-        source: ["variables"]
-      }
-  
-      AssignedVariablesList 
-      { 
-        name: "interactions"; 
-        title: qsTr("Model terms"); 
-        listViewType:"Interaction"
-        ExtraControlColumn {
-          type: "CheckBox"
-          name: "polynoms"
-          title: "Add as a polynomial"
-        }
-      }
-    }
-  }  
-  
-  ExpanderButton{
-    title: qsTr("Visual Fitting")  
-        DropDown{
-	        name: "linetype"
-	        values: ["Regression", "Quadratic", "Cubic"]
-	        label: qsTr("Fitted line (scatterplots)")
-	         enabled: vars.count > 0
-        }
-        
-  }
+	Section
+	{
+		title: qsTr("Model Terms");
+		enabled: varlist.count > 1
 
-  
-
-  
-		
-  ExpanderButton{
-    title: qsTr("Results Displays")
-
-    Group{
-    title: qsTr("Plots")
-		  CheckBox{
-			  name:"model"; 
-			  label: qsTr("Model plot");
-			  checked: true
-			  }
-      CheckBox{
-			  name:"univariate"; 
-			  label: qsTr("Univariate")
-			  }
-      CheckBox{
-			  name:"residuals"; 
-			  label: qsTr("Diagnostics")
-			  }
-      CheckBox{
-			  name:"avp"; 
-			  label: qsTr("Added variable plot");
-			  enabled: vars.count > 1 
-			  }			  
-		  }
-		  
-		  
-		Group{
-    title: qsTr("Estimation")
-      CheckBox{
-			  name:"modinf"; 
-			  label: qsTr("Show model comparisons");
-			  enabled: vars.count > 1 			  
-			}	
-      CheckBox{
-			  name:"means"; 
-			  label: qsTr("Report means");
-			  checked: true
-			}	
-      CheckBox{
-			  name:"diff"; 
-			  label: qsTr("Show mean differences")
-			  checked: true
-			}	
-      CheckBox{
-			  name:"sl"; 
-			  label: qsTr("Show slopes/intercepts");
-			  checked: true
-			}		
-      CheckBox{
-			  name:"ci"; 
-			  label: qsTr("Show 95% intervals");
-			  checked: true
-			}	 			
+		VariablesForm
+		{
+			height: 150
+			AvailableVariablesList	{ name: "components"	; title: qsTr("Components")	; source: ["variables"] }
+			AssignedVariablesList	{ name: "interactions"	; title: qsTr("Model terms"); listViewType: JASP.Interaction
+				rowComponentsTitles: ["Add as a polynomial"]
+				rowComponents: [ Component { CheckBox { name: "polynoms" } } ]
+			}
 		}
 	}
-		
-		  ExpanderButton
-  {
-      title: qsTr("Plot Controls")
-      
-        Group{
-        title: qsTr("Point controls")
-        columns: 4
-		        Slider{
-              name: "alpha"
-              label: qsTr("Point transparency")
-              value: 0.4
-              vertical: true
-              enabled: varlist.count > 0
-            }
-		        Slider{
-              name: "jitx"
-              label: qsTr("Jitter in X")
-              value: .1
-              min: 0
-              max: .5
-              vertical: true
-              enabled: varlist.count > 0
-            }  
-		        Slider{
-              name: "jity"
-              label: qsTr("Jitter in Y")
-              value: 0
-              min: 0
-              max: .5
-              vertical: true
-              enabled: varlist.count > 0
-            }   
-        }
-        Group{
-        title: qsTr("Aesthetics")
-            DropDown{
-			        name: "theme"
-			        values: ["JASP", "Black and white", "Minimal", "Classic", "Dark"]
-			        label: qsTr("GGplot theme")
-		        }
-		        CheckBox{
-              name:"ghost"; 
-              label: qsTr("Ghost lines");
-              checked: true
-              enabled: vars.count > 1 & vars.count< 4
-            }  
-        }
 
-  }
-  
-  
+	Section
+	{
+		title: qsTr("Visual Fitting")
+		DropDown
+		{
+			name: "linetype"
+			values: ["Regression", "Quadratic", "Cubic"]
+			label: qsTr("Fitted line (scatterplots)")
+			enabled: varlist.count > 0
+		}
+
+	}
+
+	Section
+	{
+		title: qsTr("Results Displays")
+
+		Group
+		{
+			title: qsTr("Plots")
+			CheckBox { name:"model"			; label: qsTr("Model plot")	; checked: true							}
+			CheckBox { name:"univariate"	; label: qsTr("Univariate")											}
+			CheckBox { name:"residuals"		; label: qsTr("Diagnostics")										}
+			CheckBox { name:"avp"			; label: qsTr("Added variable plot")	; enabled: varlist.count > 1	}
+		}
+
+
+		Group
+		{
+			title: qsTr("Estimation")
+			CheckBox { name:"modinf"		; label: qsTr("Show model comparisons")	; enabled: varlist.count > 1	}
+			CheckBox { name:"means"			; label: qsTr("Report means")			; checked: true				}
+			CheckBox { name:"diff"			; label: qsTr("Show mean differences")	; checked: true				}
+			CheckBox { name:"sl"			; label: qsTr("Show slopes/intercepts")	; checked: true				}
+			CheckBox { name:"ci"			; label: qsTr("Show 95% intervals")		; checked: true				}
+		}
+	}
+
+	Section
+	{
+		title: qsTr("Plot Controls")
+
+		Group
+		{
+			title: qsTr("Point controls")
+			columns: 4
+			Slider
+			{
+				name: "alpha"
+				label: qsTr("Point transparency")
+				value: 0.4
+				vertical: true
+				enabled: varlist.count > 0
+			}
+			Slider
+			{
+				name: "jitx"
+				label: qsTr("Jitter in X")
+				value: .1
+				min: 0
+				max: .5
+				vertical: true
+				enabled: varlist.count > 0
+			}
+			Slider
+			{
+				name: "jity"
+				label: qsTr("Jitter in Y")
+				value: 0
+				min: 0
+				max: .5
+				vertical: true
+				enabled: varlist.count > 0
+			}
+		}
+		Group
+		{
+			title: qsTr("Aesthetics")
+			DropDown
+			{
+				name: "theme"
+				values: ["JASP", "Black and white", "Minimal", "Classic", "Dark"]
+				label: qsTr("GGplot theme")
+			}
+			CheckBox
+			{
+				name:"ghost";
+				label: qsTr("Ghost lines");
+				checked: true
+				enabled: varlist.count > 1 & varlist.count< 4
+			}
+		}
+	}
 }

--- a/inst/qml/mixedmod.qml
+++ b/inst/qml/mixedmod.qml
@@ -1,156 +1,83 @@
-import QtQuick 2.8
-import JASP.Controls 1.0
-import JASP.Widgets 1.0
-import JASP.Theme 1.0
+import QtQuick			2.12
+import JASP.Controls	1.0
+import JASP.Widgets		1.0
+import JASP				1.0
+
 Form 
 {
-  usesJaspResults: true
-
-  VariablesForm
+	VariablesForm
 	{
-    AvailableVariablesList { 
-      name: "allVariables" 
-    }
-    AssignedVariablesList { 
-			name: "dependent";	
-			title: qsTr("Dependent Variable");
-			singleVariable: true 
-		}
-		AssignedVariablesList { 
-		  id: vars
-			name: "variables";	
-			title: qsTr("Independent Variable(s)");
-			singleVariable: false 
-		}
-		AssignedVariablesList { 
-			name: "rvariables";	
-			title: qsTr("Random");
-			singleVariable: true 
-		}		
-  }
-  
-  ExpanderButton{
-    title: qsTr("Model Builder")  
-    VariablesForm
-    {
-      height: 150
-      AvailableVariablesList { 
-        name: "components"; 
-        title: qsTr("Components"); 
-        source: ["variables"] 
-      }
-  
-      AssignedVariablesList 
-      { 
-        name: "interactions"; 
-        title: qsTr("Fixed terms"); 
-        listViewType:"Interaction"
-  
-        ExtraControlColumn {
-          type: "CheckBox"
-          name: "randeff2"
-          title: "Add as a random effect"
-        }
-      }
-    }
-  }
+		AvailableVariablesList	{ name: "allVariables" }
+		AssignedVariablesList	{ name: "dependent"		; title: qsTr("Dependent Variable")			; singleVariable: true	}
+		AssignedVariablesList	{ name: "variables"		; title: qsTr("Independent Variable(s)")	; id: varlist			}
+		AssignedVariablesList	{ name: "rvariables"	; title: qsTr("Random")						; singleVariable: true	}
+	}
 
-		
-  ExpanderButton{
-    title: qsTr("Results Displays")
-
-    Group{
-    title: qsTr("Plots")
-		  CheckBox{
-			  name:"model"; 
-			  label: qsTr("Model plot");
-			  checked: true
-			  }
-			  
-		  CheckBox{
-			  name:"univariates"; 
-			  label: qsTr("Univariate plots");
-			  checked: true
-			  }	
-
-      CheckBox{
-			  name:"residuals"; 
-			  label: qsTr("Diagnostics")
-			  }
-			  
-		  }
-		Group{
-    title: qsTr("Estimation")
-      CheckBox{
-			  name:"fixeff"; 
-			  label: qsTr("Report fixed effects");
-			  checked: true
-			}	
-      CheckBox{
-			  name:"randeff"; 
-			  label: qsTr("Report random effects")
-			  checked: false
-			}	
+	Section
+	{
+		title: qsTr("Model Builder")
+		VariablesForm
+		{
+			height: 150
+			AvailableVariablesList	{ name: "components"	; title: qsTr("Components")	; source: ["variables"] }
+			AssignedVariablesList	{ name: "interactions"	; title: qsTr("Fixed terms"); listViewType: JASP.Interaction
+				rowComponentsTitles: ["Add as a random effect"]
+				rowComponents: [ Component { CheckBox { name: "randeff2" } } ]
+			}
 		}
+	}
+
+	Section
+	{
+		title: qsTr("Results Displays")
+
+		Group
+		{
+			title: qsTr("Plots")
+			CheckBox { name:"model"			; label: qsTr("Model plot")			; checked: true }
+			CheckBox { name:"univariates"	; label: qsTr("Univariate plots")	; checked: true }
+			CheckBox { name:"residuals"		; label: qsTr("Diagnostics")						}
 
 		}
-		  
-		  
+		Group
+		{
+			title: qsTr("Estimation")
+			CheckBox { name:"fixeff"	; label: qsTr("Report fixed effects")	; checked: true		}
+			CheckBox { name:"randeff"	; label: qsTr("Report random effects")	; checked: false	}
+		}
+	}
 
-		
-		  ExpanderButton
-  {
-      title: qsTr("Plot Controls")
-      
-        Group{
-        title: qsTr("Point controls")
-        columns: 4
-		        Slider{
-              name: "alpha"
-              label: qsTr("Point transparency")
-              value: 0.4
-              vertical: true
-              enabled: varlist.count > 0
-            }
-		        Slider{
-              name: "jitx"
-              label: qsTr("Jitter in X")
-              value: .1
-              min: 0
-              max: .5
-              vertical: true
-              enabled: varlist.count > 0
-            }  
-		        Slider{
-              name: "jity"
-              label: qsTr("Jitter in Y")
-              value: 0
-              min: 0
-              max: .5
-              vertical: true
-              enabled: varlist.count > 0
-            }   
-        }
-        Group{
-        title: qsTr("Other parameters")
-            DropDown{
-			        name: "theme"
-			        values: ["JASP", "Black and white", "Minimal", "Classic", "Dark"]
-			        label: qsTr("GGplot theme")
-		        }
-		      IntegerField{
-          name: "nsamp"
-          label: qsTr("Number of clusters")
-          defaultValue: 3
-          min: 1
-          max: 20
-          enabled: varlist.count > 0
-        }   
-        }
+	Section
+	{
+		title: qsTr("Plot Controls")
 
-  }
-  
-	
-  
- 
+		Group
+		{
+			title: qsTr("Point controls")
+			columns: 4
+			Slider { name: "alpha"	; label: qsTr("Point transparency")	; value: 0.4; vertical: true	; enabled: varlist.count > 0					}
+			Slider { name: "jitx"	; label: qsTr("Jitter in X")		; value: .1	; vertical: true	; enabled: varlist.count > 0; min: 0; max: .5;	}
+			Slider { name: "jity"	; label: qsTr("Jitter in Y")		; value: 0	; vertical: true	; enabled: varlist.count > 0; min: 0; max: .5	}
+		}
+
+		Group
+		{
+			title: qsTr("Other parameters")
+			DropDown
+			{
+				name: "theme"
+				values: ["JASP", "Black and white", "Minimal", "Classic", "Dark"]
+				label: qsTr("GGplot theme")
+			}
+			IntegerField
+			{
+				name: "nsamp"
+				label: qsTr("Number of clusters")
+				defaultValue: 3
+				min: 1
+				max: 20
+				enabled: varlist.count > 0
+			}
+		}
+	}
 }


### PR DESCRIPTION
Hi Dustin,

Great to see you managed to get a working flexplot version for JASP 0.12!
The plots look very nice :)

We added it to the JASP modules (in the next release we'll just be able to drop your dynamic module in, but for now it's a little awkward and requires some files to be moved around), meaning that if you install tomorrow's nightly you will be able to find "Visual Modeling" next to the other JASP modules.

Additionally I changed some of your R code to fix some errors I noticed (from memory):
- In "Linear Modeling" if you have only one variable then the "Added variable plot" crashes. I changed this to requiring two variables, but it's possible you want to fix this some other way.
- There were a number of `save()` statements
- In "Mixed Modeling" the "Report random effects" table crashes when there are no additional random effects and there was a hardcoded `"School"` there
- In `make_formula` you didn't set the `env` param, consequently `update()` could not find the dataset
- `summary(mixedmod_results...` errored because `correlation` was undefined (it does not get set in the R session within JASP), I set this to `FALSE`
- In one of your plot functions you had a  `tolower()` when indexing in the ggplot2 themes, causing a stall in JASP

And,
- Your analyses didn't show any empty plots/tables when there are no results to show. I've made this more "JASP"-like.
- `ggplot2` is required for your package (e.g., your package uses functions without namespacing), but it was listed under `imports`, I've moved this to `depends`

For QML Bruno changed:
- some references to the "variables" `AssignedVariablesList` (id: `varlist`), had a wrong name (`vars` in place of `varlist`)
- To specify that a `VariablesList` is of `Interaction` type, the `listViewType` property must be set to `JASP.Interaction` (in place of string `"Interaction"`): this is a new way to do it in JASP.
- The `ExtraControlColumns` must be replaced by a `rowComponents` (and `rowComponentsTitles`) property.
- I have changed the QML style.

There are still two open R issues that you might want to look at
1. Right after you load your datasets you always use `.unv()` on the colnames. The consequence of this is that your module is extremely vulnerable to "exotic" column names. For example, in JASP people can use spaces in column names, but if you add this variable to Flexplot, it will crash hard (because the formula `col 1 ~ col2` is not valid). Fortunately in the release after 0.12 column encoding will be automatic, but the current release does not contain this yet.
2. You use a combination of terms from the `Model Builder` / `Model Terms` and also the fields that populate those. E.g., in "Linear Modeling" add 2 variables to `Independent Variable(s)` and then move one of these two variables from `Model terms` to `Components` -- your analysis crashes. It's better to always use the model terms instead of using both the model terms and the variables field, as they might diverge.