### PR TITLE
fixes unicode stings in JASP

### DIFF
--- a/R/linmod_jasp.R
+++ b/R/linmod_jasp.R
@@ -455,11 +455,11 @@ linmod_jasp<- function(jaspResults, dataset, options) {
     linmod_table_slopes$addColumnInfo(name = "upr",      title = "Upper",       type = "number", format = "dp:2", combine = TRUE, overtitle = "95% Confidence Interval")
   }
   
-  linmod_table_slopes$addColumnInfo(name = "std",    title = "Standardized Slope (β)",       type = "number", format = "dp:2", combine = TRUE)	
+  linmod_table_slopes$addColumnInfo(name = "std",    title = "Standardized Slope (\u03B2)",       type = "number", format = "dp:2", combine = TRUE)	
   
   if (options$ci){
-    linmod_table_slopes$addColumnInfo(name = "slwr",      title = "Lower β",       type = "number", format = "dp:2", combine = TRUE, overtitle = "95% Confidence Interval")
-    linmod_table_slopes$addColumnInfo(name = "supr",      title = "Upper β",       type = "number", format = "dp:2", combine = TRUE, overtitle = "95% Confidence Interval")
+    linmod_table_slopes$addColumnInfo(name = "slwr",      title = "Lower \u03B2",       type = "number", format = "dp:2", combine = TRUE, overtitle = "95% Confidence Interval")
+    linmod_table_slopes$addColumnInfo(name = "supr",      title = "Upper \u03B2",       type = "number", format = "dp:2", combine = TRUE, overtitle = "95% Confidence Interval")
   }
   
   ### add message about what type of interval was used


### PR DESCRIPTION
try to fix https://github.com/dustinfife/flexplot/issues/86 and related https://github.com/jasp-stats/jasp-issues/issues/1488
I'm not really sure if HTML encoding `&beta` would be better than this, but we might want to use Unicode encoding in R

could @dustinfife  and @JorisGoosen comment on this? thanks